### PR TITLE
Default Excel exports to landscape layout

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -65,8 +65,6 @@ const Dashboard = ({ user }: DashboardProps) => {
         exportMenuRef={state.exportMenuRef}
         onExportPayroll={state.exportPayroll}
         onExportDetails={state.exportDetails}
-        exportOptions={state.exportOptions}
-        onToggleExportOption={state.toggleExportOption}
       />
 
       <StatsGrid totals={state.totals} hasProject={Boolean(state.projectId)} />

--- a/src/components/dashboard/Toolbar.tsx
+++ b/src/components/dashboard/Toolbar.tsx
@@ -17,11 +17,6 @@ interface ToolbarProps {
   exportMenuRef: RefObject<HTMLDivElement>;
   onExportPayroll: () => Promise<void> | void;
   onExportDetails: () => Promise<void> | void;
-  exportOptions: {
-    onePagePortrait: boolean;
-    withColors: boolean;
-  };
-  onToggleExportOption: (option: 'onePagePortrait' | 'withColors') => void;
 }
 
 const Toolbar = ({
@@ -40,8 +35,6 @@ const Toolbar = ({
   exportMenuRef,
   onExportPayroll,
   onExportDetails,
-  exportOptions,
-  onToggleExportOption,
 }: ToolbarProps) => {
   return (
     <section className="bg-white/90 border-b">
@@ -122,33 +115,6 @@ const Toolbar = ({
             </button>
             {exportOpen && (
               <div ref={exportMenuRef} className="menu" role="menu" aria-label="Menu Export">
-                <div className="px-3 py-2 text-xs font-semibold uppercase text-gray-500 border-b border-gray-100">
-                  Options
-                </div>
-                <label
-                  className="flex items-center gap-2 px-3 py-2 text-sm border-t border-b border-gray-100 first:border-t-0"
-                  role="menuitemcheckbox"
-                  aria-checked={exportOptions.onePagePortrait}
-                >
-                  <input
-                    type="checkbox"
-                    checked={exportOptions.onePagePortrait}
-                    onChange={() => onToggleExportOption('onePagePortrait')}
-                  />
-                  One-page portrait
-                </label>
-                <label
-                  className="flex items-center gap-2 px-3 py-2 text-sm border-b border-gray-100"
-                  role="menuitemcheckbox"
-                  aria-checked={exportOptions.withColors}
-                >
-                  <input
-                    type="checkbox"
-                    checked={exportOptions.withColors}
-                    onChange={() => onToggleExportOption('withColors')}
-                  />
-                  Couleurs
-                </label>
                 <button
                   type="button"
                   role="menuitem"

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -96,11 +96,6 @@ export interface DashboardState {
   refreshData: () => Promise<unknown[]>;
   exportPayroll: () => Promise<void>;
   exportDetails: () => Promise<void>;
-  exportOptions: {
-    onePagePortrait: boolean;
-    withColors: boolean;
-  };
-  toggleExportOption: (option: 'onePagePortrait' | 'withColors') => void;
   logout: () => Promise<void>;
   shiftMonth: (delta: number) => void;
   setOpenWorkers: Dispatch<SetStateAction<boolean>>;
@@ -135,7 +130,6 @@ export const useDashboardData = (user: User): DashboardState => {
   const [editingCell, setEditingCell] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState('');
   const [exportOpen, setExportOpen] = useState(false);
-  const [exportOptions, setExportOptions] = useState({ onePagePortrait: true, withColors: true });
   const exportBtnRef = useRef<HTMLButtonElement>(null);
   const exportMenuRef = useRef<HTMLDivElement>(null);
   const [modals, setModals] = useState({
@@ -752,21 +746,13 @@ export const useDashboardData = (user: User): DashboardState => {
         workers,
         entries,
         allEntries,
-        options: {
-          applyPrintSetup: exportOptions.onePagePortrait,
-          applyColors: exportOptions.withColors,
-        },
       });
       notify('success', 'Export détaillé généré.');
     } catch (error) {
       console.error('Detail export failed', error);
       notify('error', "L'export détaillé a échoué. Veuillez réessayer.");
     }
-  }, [yearMonth, projectId, projects, workers, entries, allEntries, exportOptions, notify]);
-
-  const toggleExportOption = useCallback((option: 'onePagePortrait' | 'withColors') => {
-    setExportOptions((prev) => ({ ...prev, [option]: !prev[option] }));
-  }, []);
+  }, [yearMonth, projectId, projects, workers, entries, allEntries, notify]);
 
   const logout = useCallback(async () => {
     await supabase.auth.signOut();
@@ -832,8 +818,6 @@ export const useDashboardData = (user: User): DashboardState => {
     refreshData,
     exportPayroll,
     exportDetails,
-    exportOptions,
-    toggleExportOption,
     logout,
     shiftMonth,
     setOpenWorkers,

--- a/src/services/xlsxService.ts
+++ b/src/services/xlsxService.ts
@@ -93,7 +93,7 @@ export const buildTimesheetsWorkbook = (
       worksheet.pageSetup.printTitlesRow = '1:1';
 
       if (resolvedOptions.applyPrintSetup) {
-        worksheet.pageSetup.orientation = 'portrait';
+        worksheet.pageSetup.orientation = 'landscape';
         worksheet.pageSetup.fitToPage = true;
         worksheet.pageSetup.fitToWidth = 1;
         worksheet.pageSetup.fitToHeight = 1;

--- a/tests/excelExport.test.ts
+++ b/tests/excelExport.test.ts
@@ -22,7 +22,7 @@ describe('buildTimesheetsWorkbook', () => {
     expect(worksheet).toBeDefined();
     if (!worksheet) return;
 
-    expect(worksheet.pageSetup.orientation).toBe('portrait');
+    expect(worksheet.pageSetup.orientation).toBe('landscape');
     expect(worksheet.pageSetup.fitToPage).toBe(true);
     expect(worksheet.pageSetup.fitToWidth).toBe(1);
     expect(worksheet.pageSetup.fitToHeight).toBe(1);


### PR DESCRIPTION
## Summary
- set Excel timesheet exports to landscape orientation by default while keeping print setup
- remove export menu toggles for orientation and color so the default styling is always applied

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb3e5596c4832b971ab16b11101485